### PR TITLE
Add Jest and UrlService unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "url shortener implementation using expressjs following hexagonal architecture",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",
@@ -14,6 +14,7 @@
     "mongoose": "^8.13.0"
   },
   "devDependencies": {
-    "nodemon": "^3.1.9"
+    "nodemon": "^3.1.9",
+    "jest": "^29.0.0"
   }
 }

--- a/tests/UrlService.test.js
+++ b/tests/UrlService.test.js
@@ -1,0 +1,52 @@
+const crypto = require('crypto');
+const UrlService = require('../src/domain/services/UrlService');
+const Url = require('../src/domain/entities/Url');
+const NotFoundUrlError = require('../src/domain/errors/NotFoundUrlError');
+const ExpiredUrlError = require('../src/domain/errors/ExpiredUrlError');
+
+describe('UrlService', () => {
+  describe('createShortUrl', () => {
+    it('creates and saves a new Url entity', async () => {
+      const repo = { save: jest.fn() };
+      const service = new UrlService(repo);
+      jest.spyOn(crypto, 'randomBytes').mockReturnValueOnce(Buffer.from('aabbccdd', 'hex'));
+
+      const result = await service.createShortUrl('https://example.com');
+
+      expect(repo.save).toHaveBeenCalledTimes(1);
+      expect(repo.save.mock.calls[0][0]).toBeInstanceOf(Url);
+      expect(result.shortCode).toBe('aabbccdd');
+      expect(result.originalUrl).toBe('https://example.com');
+
+      crypto.randomBytes.mockRestore();
+    });
+  });
+
+  describe('getOriginalUrl', () => {
+    it('returns the original URL when found and not expired', async () => {
+      const urlData = new Url({ originalUrl: 'https://example.com', shortCode: 'abcd1234' });
+      const repo = { findByShortCode: jest.fn().mockResolvedValue(urlData) };
+      const service = new UrlService(repo);
+
+      const originalUrl = await service.getOriginalUrl('abcd1234');
+
+      expect(originalUrl).toBe('https://example.com');
+    });
+
+    it('throws NotFoundUrlError when the short code does not exist', async () => {
+      const repo = { findByShortCode: jest.fn().mockResolvedValue(null) };
+      const service = new UrlService(repo);
+
+      await expect(service.getOriginalUrl('missing')).rejects.toBeInstanceOf(NotFoundUrlError);
+    });
+
+    it('throws ExpiredUrlError when the URL has expired', async () => {
+      const expired = new Date(Date.now() - 1000);
+      const urlData = new Url({ originalUrl: 'https://example.com', shortCode: 'expired', expiresAt: expired });
+      const repo = { findByShortCode: jest.fn().mockResolvedValue(urlData) };
+      const service = new UrlService(repo);
+
+      await expect(service.getOriginalUrl('expired')).rejects.toBeInstanceOf(ExpiredUrlError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependency and update test script
- implement tests for UrlService

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fba5983fc832cb62bce4d2840f51b